### PR TITLE
Connect possible spelling search backend

### DIFF
--- a/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
+++ b/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
@@ -3,7 +3,9 @@ import {
   DictionarySearchRow,
   DictItemComboboxDisplay,
   ItemPropertyRow,
+  SearchPossibleSpellingRow,
 } from '@oare/types';
+import { stringToCharsArray } from '../TextEpigraphyDao/utils';
 import {
   DictSpellEpigRowDictSearch,
   SearchWordsQueryRow,
@@ -153,4 +155,28 @@ export function assembleSearchResult(
     return 0;
   });
   return searchResults;
+}
+
+export async function sortRows(
+  rows: SearchPossibleSpellingRow[]
+): Promise<SearchPossibleSpellingRow[]> {
+  return rows.sort(
+    (a: SearchPossibleSpellingRow, b: SearchPossibleSpellingRow) => {
+      const aLength = stringToCharsArray(a.explicitSpelling).length;
+      const bLength = stringToCharsArray(b.explicitSpelling).length;
+      if (aLength !== bLength) {
+        return aLength - bLength;
+      }
+      const aCharsArray = stringToCharsArray(a.explicitSpelling);
+      const bCharsArray = stringToCharsArray(b.explicitSpelling);
+      for (let i = 0; i < aLength; i += 1) {
+        if (aCharsArray[i] !== bCharsArray[i]) {
+          return aCharsArray[i]
+            .replace(/(\(d\))|(\(m\))/g, '')
+            .localeCompare(bCharsArray[i].replace(/(\(d\))|(\(m\))/g, ''));
+        }
+      }
+      return a.explicitSpelling.length - b.explicitSpelling.length;
+    }
+  );
 }

--- a/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
+++ b/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
@@ -251,7 +251,7 @@ export const formattedSearchCharacter = (char: string): string[] => {
 export const stringToCharsArray = (search: string): string[] => {
   const chars = search
     .trim()
-    .split(/[\s\-.+]+/)
+    .split(/[\s\-.+=]+/)
     .flatMap(formattedSearchCharacter);
 
   if (chars.length === 1 && chars[0] === '') {

--- a/packages/frontend/src/serverProxy/search.ts
+++ b/packages/frontend/src/serverProxy/search.ts
@@ -7,6 +7,7 @@ import {
   SearchDiscourseSpellingResponse,
   Pagination,
   SearchNullDiscourseResultRow,
+  SearchPossibleSpellingResultRow,
 } from '@oare/types';
 
 async function searchTexts(
@@ -27,6 +28,18 @@ async function searchSpellings(
   spelling: string
 ): Promise<SearchSpellingResultRow[]> {
   const { data } = await axios.get('/search/spellings', {
+    params: {
+      spelling,
+    },
+  });
+
+  return data;
+}
+
+async function searchPossibleSpellings(
+  spelling: string
+): Promise<SearchPossibleSpellingResultRow[]> {
+  const { data } = await axios.get('/search/possible_spellings', {
     params: {
       spelling,
     },
@@ -82,6 +95,7 @@ async function searchNullDiscourseCount(
 
 export default {
   searchSpellings,
+  searchPossibleSpellings,
   searchSpellingDiscourse,
   searchTexts,
   searchTextsTotal,

--- a/packages/types/src/dictionary.ts
+++ b/packages/types/src/dictionary.ts
@@ -1,6 +1,7 @@
 import { DictionaryWordTranslation, Word, ItemPropertyRow } from './words';
 import { SearchTextsResultRow } from './search';
 import { FieldInfo } from './field';
+import { PossibleSign } from './sign_reading';
 
 export interface DisplayableWord {
   uuid: string;
@@ -110,6 +111,23 @@ export interface SearchSpellingResultRow {
   spellingUuid: string;
   occurrences: number;
   wordInfo: Word;
+}
+
+export interface SearchPossibleSpellingResultRow {
+  wordUuid: string;
+  word: string;
+  form: Omit<DictionaryForm, 'spellings'>;
+  spellingUuid: string;
+  possibleSigns: PossibleSign[];
+}
+
+export interface SearchPossibleSpellingRow {
+  wordUuid: string;
+  word: string;
+  formUuid: string;
+  form: string;
+  spellingUuid: string;
+  explicitSpelling: string;
 }
 
 export interface SearchSpellingPayload {

--- a/packages/types/src/sign_reading.ts
+++ b/packages/types/src/sign_reading.ts
@@ -49,3 +49,13 @@ export interface SignListPayload {
   sortBy: string;
   allSigns: string;
 }
+
+export interface PossibleSign {
+  signUuid: string;
+  reading: string;
+  name: string;
+  signSpellNum: number;
+  code: string | null;
+  hasPng: number;
+  mzl: string;
+}


### PR DESCRIPTION
creates part 1 of the backend for connecting possible spellings. This part is the functionality that is needed for users to view possible spellings for a word with broken signs. I will do the part that actually connects those spellings later. closes #1689.