### PR TITLE
Connect spelling search frontend

### DIFF
--- a/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
+++ b/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
@@ -3,7 +3,9 @@ import {
   DictionarySearchRow,
   DictItemComboboxDisplay,
   ItemPropertyRow,
+  SearchPossibleSpellingRow,
 } from '@oare/types';
+import { stringToCharsArray } from '../TextEpigraphyDao/utils';
 import {
   DictSpellEpigRowDictSearch,
   SearchWordsQueryRow,
@@ -153,4 +155,28 @@ export function assembleSearchResult(
     return 0;
   });
   return searchResults;
+}
+
+export async function sortRows(
+  rows: SearchPossibleSpellingRow[]
+): Promise<SearchPossibleSpellingRow[]> {
+  return rows.sort(
+    (a: SearchPossibleSpellingRow, b: SearchPossibleSpellingRow) => {
+      const aLength = stringToCharsArray(a.explicitSpelling).length;
+      const bLength = stringToCharsArray(b.explicitSpelling).length;
+      if (aLength !== bLength) {
+        return aLength - bLength;
+      }
+      const aCharsArray = stringToCharsArray(a.explicitSpelling);
+      const bCharsArray = stringToCharsArray(b.explicitSpelling);
+      for (let i = 0; i < aLength; i += 1) {
+        if (aCharsArray[i] !== bCharsArray[i]) {
+          return aCharsArray[i]
+            .replace(/(\(d\))|(\(m\))/g, '')
+            .localeCompare(bCharsArray[i].replace(/(\(d\))|(\(m\))/g, ''));
+        }
+      }
+      return a.explicitSpelling.length - b.explicitSpelling.length;
+    }
+  );
 }

--- a/packages/backend/src/api/daos/TextDiscourseDao/index.ts
+++ b/packages/backend/src/api/daos/TextDiscourseDao/index.ts
@@ -885,7 +885,7 @@ class TextDiscourseDao {
       .select('type')
       .where({ uuid: discourseUuid })
       .first()
-      .then(row => row.type);
+      .then(row => row?.type);
 
     if (type === 'discourseUnit') {
       return [];

--- a/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
+++ b/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
@@ -317,19 +317,25 @@ export async function getInterlinearInfo(
           wordUuid = await DictionaryFormDao.getDictionaryWordUuidByFormUuid(
             formUuid
           );
-          const { type } = await DictionaryWordDao.getDictionaryWordRowByUuid(
-            wordUuid
-          );
-          if (type === 'GN') {
-            translation = 'GN';
-          } else if (type === 'PN') {
-            translation = 'PN';
-          } else {
-            translation = (
-              await DictionaryWordDao.getWordTranslationsForDefinition(wordUuid)
-            )[0].val;
+          if (wordUuid) {
+            const type = (
+              await DictionaryWordDao.getDictionaryWordRowByUuid(wordUuid)
+            )?.type;
+            if (type) {
+              if (type === 'GN') {
+                translation = 'GN';
+              } else if (type === 'PN') {
+                translation = 'PN';
+              } else {
+                translation = (
+                  await DictionaryWordDao.getWordTranslationsForDefinition(
+                    wordUuid
+                  )
+                )[0]?.val;
+              }
+              word = await DictionaryWordDao.getWordName(wordUuid);
+            }
           }
-          word = await DictionaryWordDao.getWordName(wordUuid);
           parseInfo = await ItemPropertiesDao.getPropertiesByReferenceUuid(
             formUuid
           );

--- a/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
+++ b/packages/backend/src/api/daos/TextEpigraphyDao/utils.ts
@@ -251,7 +251,7 @@ export const formattedSearchCharacter = (char: string): string[] => {
 export const stringToCharsArray = (search: string): string[] => {
   const chars = search
     .trim()
-    .split(/[\s\-.+]+/)
+    .split(/[\s\-.+=]+/)
     .flatMap(formattedSearchCharacter);
 
   if (chars.length === 1 && chars[0] === '') {

--- a/packages/backend/src/api/daos/TextMarkupDao/index.ts
+++ b/packages/backend/src/api/daos/TextMarkupDao/index.ts
@@ -39,11 +39,12 @@ class TextMarkupDao {
 
     markups.sort(a => {
       if (
-        a.type === 'damage' ||
-        a.type === 'partialDamage' ||
-        a.type === 'isCollatedReading' ||
-        a.type === 'isEmendedReading' ||
-        a.type === 'uncertain'
+        a &&
+        (a.type === 'damage' ||
+          a.type === 'partialDamage' ||
+          a.type === 'isCollatedReading' ||
+          a.type === 'isEmendedReading' ||
+          a.type === 'uncertain')
       ) {
         return -1;
       }

--- a/packages/backend/src/api/search.ts
+++ b/packages/backend/src/api/search.ts
@@ -142,6 +142,7 @@ router.route('/search/possible_spellings').get(async (req, res, next) => {
       },
       spellingUuid: row.spellingUuid,
       possibleSigns: possibleSigns[i],
+      explicitSpelling: row.explicitSpelling,
     }));
     res.json(results);
   } catch (err) {

--- a/packages/frontend/src/components/base/OareDialog.vue
+++ b/packages/frontend/src/components/base/OareDialog.vue
@@ -33,7 +33,10 @@
       <v-card-text>
         <slot></slot>
       </v-card-text>
-      <div v-if="showCancel || showSubmit">
+      <div
+        v-if="showCancel || showSubmit"
+        :class="{ 'sticky-submit': stickyAction }"
+      >
         <v-divider />
         <v-card-actions>
           <v-spacer />
@@ -155,6 +158,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    stickyAction: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup({ closeOnSubmit }, { emit }) {
     const submit = () => {
@@ -170,3 +177,10 @@ export default defineComponent({
   },
 });
 </script>
+<style>
+.sticky-submit {
+  position: sticky;
+  bottom: 0;
+  background: white;
+}
+</style>

--- a/packages/frontend/src/serverProxy/search.ts
+++ b/packages/frontend/src/serverProxy/search.ts
@@ -7,6 +7,7 @@ import {
   SearchDiscourseSpellingResponse,
   Pagination,
   SearchNullDiscourseResultRow,
+  SearchPossibleSpellingResultRow,
 } from '@oare/types';
 
 async function searchTexts(
@@ -27,6 +28,18 @@ async function searchSpellings(
   spelling: string
 ): Promise<SearchSpellingResultRow[]> {
   const { data } = await axios.get('/search/spellings', {
+    params: {
+      spelling,
+    },
+  });
+
+  return data;
+}
+
+async function searchPossibleSpellings(
+  spelling: string
+): Promise<SearchPossibleSpellingResultRow[]> {
+  const { data } = await axios.get('/search/possible_spellings', {
     params: {
       spelling,
     },
@@ -82,6 +95,7 @@ async function searchNullDiscourseCount(
 
 export default {
   searchSpellings,
+  searchPossibleSpellings,
   searchSpellingDiscourse,
   searchTexts,
   searchTextsTotal,

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/ConnectPossibleSpellingOccurrence.vue
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/ConnectPossibleSpellingOccurrence.vue
@@ -45,7 +45,10 @@
           }}</span>
         </template>
         <template #[`item.context`]="{ item }">
-          <epigraphy-context :spellingUuid="item.spellingUuid" />
+          <epigraphy-context
+            class="test-context"
+            :spellingUuid="item.spellingUuid"
+          />
         </template>
         <template #[`item.possibleSigns`]="{ item }">
           <span v-for="(sign, idx) in item.possibleSigns" :key="idx"

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/ConnectSpellingOccurrence.vue
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/ConnectSpellingOccurrence.vue
@@ -45,7 +45,10 @@
           }}</span>
         </template>
         <template #[`item.context`]="{ item }">
-          <epigraphy-context :spellingUuid="item.spellingUuid" />
+          <epigraphy-context
+            class="test-context"
+            :spellingUuid="item.spellingUuid"
+          />
         </template>
         <template #[`item.connect`]="{ item }">
           <div class="d-flex justify-center">

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/EpigraphyContext.vue
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/EpigraphyContext.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <v-progress-circular v-if="loading" indeterminate />
+    <div v-else>
+      <div v-if="textOccurrence.length > 0">
+        <div class="py-1">
+          <router-link
+            v-if="textOccurrence.length > 0"
+            :to="`/epigraphies/${textOccurrence[0].textUuid}/${
+              textOccurrence[0].discoursesToHighlight ||
+              textOccurrence[0].discourseUuid
+            }`"
+            class="test-text"
+            target="_blank"
+            >{{ textOccurrence[0].textName }}</router-link
+          >
+        </div>
+        <div
+          v-for="(reading, index) in textOccurrence[0].readings"
+          class="test-reading"
+          :key="index"
+          v-html="reading"
+        />
+      </div>
+      <span v-else v-html="'n/a'"></span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from '@vue/composition-api';
+import { TextOccurrencesResponseRow } from '@oare/types';
+import sl from '@/serviceLocator';
+
+export default defineComponent({
+  props: {
+    spellingUuid: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const actions = sl.get('globalActions');
+    const server = sl.get('serverProxy');
+
+    const textOccurrence = ref<TextOccurrencesResponseRow[]>([]);
+    const loading = ref(false);
+
+    onMounted(async () => {
+      try {
+        loading.value = true;
+        textOccurrence.value = await server.getSpellingOccurrencesTexts(
+          [props.spellingUuid],
+          {
+            page: 1,
+            limit: 1,
+          }
+        );
+        loading.value = false;
+      } catch (err) {
+        actions.showErrorSnackbar('Failed on mount', err as Error);
+      }
+    });
+
+    return {
+      textOccurrence,
+      loading,
+    };
+  },
+});
+</script>

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/EpigraphyReading.vue
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/EpigraphyReading.vue
@@ -355,7 +355,7 @@ import DictionaryWord from '@/views/DictionaryWord/index.vue';
 import SealList from '@/views/Seals/SealList.vue';
 import SingleSeal from '@/views/Seals/SingleSeal.vue';
 import ConnectSpellingOccurrence from './ConnectSpellingOccurrence.vue';
-import ConnectPossibleSpellingOccurrence from './ConnectPossibleSpellingOccurence.vue';
+import ConnectPossibleSpellingOccurrence from './ConnectPossibleSpellingOccurrence.vue';
 import UtilList from '@/components/UtilList/index.vue';
 import { formatLineNumber, romanNumeral } from '@oare/oare/src/tabletUtils';
 import i18n from '@/i18n';

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/__tests__/ConnectPossibleSpellingOccurrence.test.js
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/__tests__/ConnectPossibleSpellingOccurrence.test.js
@@ -3,13 +3,13 @@ import VueCompositionApi from '@vue/composition-api';
 import { mount, createLocalVue } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import sl from '@/serviceLocator';
-import ConnectSpellingOccurrence from '../ConnectSpellingOccurrence.vue';
+import ConnectPossibleSpellingOccurrence from '../ConnectPossibleSpellingOccurrence.vue';
 
 const vuetify = new Vuetify();
 const localVue = createLocalVue();
 localVue.use(VueCompositionApi);
 
-describe('Connect Spelling Occurence test', () => {
+describe('Connect Possible Spelling Occurence test', () => {
   const mockForm = {
     uuid: 'uuid',
     form: 'form',
@@ -32,17 +32,29 @@ describe('Connect Spelling Occurence test', () => {
     readings: ['reading1', 'reading2'],
   };
 
+  const possibleSign = {
+    signUuid: 'signUuid',
+    reading: 'reading',
+    name: 'name',
+    signSpellNum: 2,
+    code: 'code',
+    hasPng: 1,
+    mzl: '809',
+  };
+
   const searchSpellingResultRow = {
     wordUuid: 'wordUuid',
     word: 'word',
     form: mockForm,
     spellingUuid: 'spellingUuid',
-    occurrences: 2,
+    possibleSigns: [possibleSign],
     wordInfo: mockWord,
   };
 
   const mockServer = {
-    searchSpellings: jest.fn().mockResolvedValue([searchSpellingResultRow]),
+    searchPossibleSpellings: jest
+      .fn()
+      .mockResolvedValue([searchSpellingResultRow]),
     getSpellingTextOccurrences: jest
       .fn()
       .mockResolvedValue([spellingOccurrenceRow]),
@@ -51,8 +63,8 @@ describe('Connect Spelling Occurence test', () => {
 
   const mockProps = {
     discourseUuid: spellingOccurrenceRow.discourseUuid,
-    spelling: 'spelling',
-    searchSpellings: mockServer.searchSpellings,
+    spelling: 'spelling-x',
+    searchPossibleSpellings: mockServer.searchPossibleSpellings,
   };
 
   const mockActions = {
@@ -76,7 +88,7 @@ describe('Connect Spelling Occurence test', () => {
   beforeEach(setup);
 
   const createWrapper = (props = mockProps) =>
-    mount(ConnectSpellingOccurrence, {
+    mount(ConnectPossibleSpellingOccurrence, {
       localVue,
       vuetify,
       propsData: props,
@@ -86,7 +98,9 @@ describe('Connect Spelling Occurence test', () => {
   it('gets dictionary info and text occurrences', async () => {
     const wrapper = createWrapper();
     await flushPromises();
-    expect(mockProps.searchSpellings).toHaveBeenCalledWith(mockProps.spelling);
+    expect(mockProps.searchPossibleSpellings).toHaveBeenCalledWith(
+      mockProps.spelling
+    );
 
     const word = await wrapper.findAll('.test-word').at(0);
     expect(word.exists()).toBe(true);
@@ -97,7 +111,7 @@ describe('Connect Spelling Occurence test', () => {
   it('shows error when mount fails', async () => {
     const props = {
       ...mockProps,
-      searchSpellings: jest
+      searchPossibleSpellings: jest
         .fn()
         .mockRejectedValue('Error, unable to retrieve text occurrences'),
     };

--- a/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/__tests__/ConnectSpellingOccurence.test.js
+++ b/packages/frontend/src/views/Texts/EpigraphyView/EpigraphyDisplay/components/__tests__/ConnectSpellingOccurence.test.js
@@ -91,7 +91,7 @@ describe('Connect Spelling Occurence test', () => {
 
     const word = await wrapper.findAll('.test-word').at(0);
     expect(word.exists()).toBe(true);
-    const reading = await wrapper.findAll('.test-reading').at(0);
+    const reading = await wrapper.findAll('.test-context').at(0);
     expect(reading.exists()).toBe(true);
   });
 

--- a/packages/types/src/dictionary.ts
+++ b/packages/types/src/dictionary.ts
@@ -1,6 +1,7 @@
 import { DictionaryWordTranslation, Word, ItemPropertyRow } from './words';
 import { SearchTextsResultRow } from './search';
 import { FieldInfo } from './field';
+import { PossibleSign } from './sign_reading';
 
 export interface DisplayableWord {
   uuid: string;
@@ -110,6 +111,23 @@ export interface SearchSpellingResultRow {
   spellingUuid: string;
   occurrences: number;
   wordInfo: Word;
+}
+
+export interface SearchPossibleSpellingResultRow {
+  wordUuid: string;
+  word: string;
+  form: Omit<DictionaryForm, 'spellings'>;
+  spellingUuid: string;
+  possibleSigns: PossibleSign[];
+}
+
+export interface SearchPossibleSpellingRow {
+  wordUuid: string;
+  word: string;
+  formUuid: string;
+  form: string;
+  spellingUuid: string;
+  explicitSpelling: string;
 }
 
 export interface SearchSpellingPayload {

--- a/packages/types/src/dictionary.ts
+++ b/packages/types/src/dictionary.ts
@@ -119,6 +119,7 @@ export interface SearchPossibleSpellingResultRow {
   form: Omit<DictionaryForm, 'spellings'>;
   spellingUuid: string;
   possibleSigns: PossibleSign[];
+  explicitSpelling: string;
 }
 
 export interface SearchPossibleSpellingRow {
@@ -237,6 +238,13 @@ export interface EditPropertiesPayload {
 export interface ConnectSpellingDiscoursePayload {
   discourseUuid: string;
   spellingUuid: string;
+}
+
+export interface ConnectSpellingDiscourseSelection {
+  discourseUuid: string;
+  spellingUuid: string;
+  explicitSpelling: string;
+  form: Omit<DictionaryForm, 'spellings'>;
 }
 
 export interface TextOccurrencesCountResponseItem {

--- a/packages/types/src/sign_reading.ts
+++ b/packages/types/src/sign_reading.ts
@@ -49,3 +49,13 @@ export interface SignListPayload {
   sortBy: string;
   allSigns: string;
 }
+
+export interface PossibleSign {
+  signUuid: string;
+  reading: string;
+  name: string;
+  signSpellNum: number;
+  code: string | null;
+  hasPng: number;
+  mzl: string;
+}


### PR DESCRIPTION
closes #1690. This creates a new component `ConnectPossibleSpellingOccurrence.vue` that searches for possible spellings given the placement of broken signs and known signs. Due to the number of possibilities that could come up with such a search, I made another component called `EpigraphyConext.vue`. This component will allow the words to be displayed fairly quickly while context loads (it takes a lot longer). Only those contexts that will be displayed are loaded, making this much faster than it would have been. I also added this to `ConnectSpellingOccurrence.vue`