### PR TITLE
searches for persons in words in texts

### DIFF
--- a/packages/backend/src/api/daos/DictionaryWordDao/index.ts
+++ b/packages/backend/src/api/daos/DictionaryWordDao/index.ts
@@ -522,7 +522,7 @@ class DictionaryWordDao {
 
   async getDictItemsForWordsInTexts(trx?: Knex.Transaction) {
     const k = trx || knexRead();
-    const forms: WordFormSpellingRow[] = await k('dictionary_form AS df')
+    const forms: WordFormSpellingRow[] = await k('dictionary_form as df')
       .join('dictionary_word as dw', 'dw.uuid', 'df.reference_uuid')
       .select(
         'df.form as name',
@@ -532,7 +532,7 @@ class DictionaryWordDao {
         'dw.uuid as wordUuid'
       );
     const spellings: WordFormSpellingRow[] = await k(
-      'dictionary_spelling AS ds'
+      'dictionary_spelling as ds'
     )
       .join('dictionary_form as df', 'df.uuid', 'ds.reference_uuid')
       .join('dictionary_word as dw', 'dw.uuid', 'df.reference_uuid')
@@ -543,15 +543,24 @@ class DictionaryWordDao {
         'dw.word as wordName',
         'dw.uuid as wordUuid'
       );
-    const words: WordFormSpellingRow[] = await k(
-      'dictionary_word as dw'
-    ).select(
-      'dw.word as name',
-      'dw.uuid',
-      'dw.uuid as referenceUuid',
-      'dw.word as wordName',
-      'dw.uuid as wordUuid'
-    );
+    const words: WordFormSpellingRow[] = await k('dictionary_word as dw')
+      .select(
+        'dw.word as name',
+        'dw.uuid',
+        'dw.uuid as referenceUuid',
+        'dw.word as wordName',
+        'dw.uuid as wordUuid'
+      )
+      .whereNot('dw.type', 'PN');
+    const personNames: WordFormSpellingRow[] = await k('dictionary_word as dw')
+      .select(
+        'dw.word as name',
+        'dw.uuid',
+        'dw.uuid as referenceUuid',
+        'dw.word as wordName',
+        'dw.uuid as wordUuid'
+      )
+      .where('dw.type', 'PN');
 
     const wordFormSpellingArray: WordFormSpellingType[] = [
       ...forms.map(form => ({
@@ -569,6 +578,14 @@ class DictionaryWordDao {
         referenceUuid: word.referenceUuid,
         wordName: word.wordName,
         wordUuid: word.wordUuid,
+      })),
+      ...personNames.map(pn => ({
+        name: pn.name,
+        uuid: pn.uuid,
+        type: 'person',
+        referenceUuid: pn.referenceUuid,
+        wordName: pn.wordName,
+        wordUuid: pn.wordUuid,
       })),
       ...spellings.map(spelling => ({
         name: spelling.name,

--- a/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
+++ b/packages/backend/src/api/daos/DictionaryWordDao/utils.ts
@@ -11,7 +11,7 @@ import {
 } from './index';
 
 export interface WordFormSpellingType extends WordFormSpellingRow {
-  type: 'word' | 'form' | 'spelling';
+  type: 'word' | 'form' | 'spelling' | 'person';
 }
 
 function mapWordsToRows(wordRows: SearchWordsQueryRow[]) {

--- a/packages/backend/src/api/daos/PersonDao/index.ts
+++ b/packages/backend/src/api/daos/PersonDao/index.ts
@@ -538,6 +538,28 @@ class PersonDao {
       roleNotYetAssigned: 0,
     };
   }
+
+  async getPersonsByNameUuid(
+    nameUuid: string,
+    trx?: Knex.Transaction
+  ): Promise<PersonRow[]> {
+    const k = trx || knexRead();
+    const query = k('person')
+      .select(
+        'person.uuid',
+        'name_uuid AS nameUuid',
+        'relation',
+        'relation_name_uuid AS relationNameUuid',
+        'label',
+        'person.type',
+        'descriptor'
+      )
+      .leftJoin('dictionary_word', 'person.name_uuid', 'dictionary_word.uuid')
+      .where('person.type', 'person')
+      .andWhere('person.name_uuid', nameUuid);
+
+    return query;
+  }
 }
 
 export default new PersonDao();

--- a/packages/backend/src/api/daos/TextDiscourseDao/index.ts
+++ b/packages/backend/src/api/daos/TextDiscourseDao/index.ts
@@ -180,6 +180,16 @@ class TextDiscourseDao {
               .from('text_discourse as td')
               .whereIn('td.explicit_spelling', dictItemSearchUuids);
           })
+          .union(function () {
+            this.select('td.uuid')
+              .from('text_discourse as td')
+              .innerJoin(
+                'item_properties as ip',
+                'ip.reference_uuid',
+                'td.uuid'
+              )
+              .whereIn('ip.object_uuid', dictItemSearchUuids);
+          })
           .modify(qb => {
             if (dictItemSearchUuids.includes('-1')) {
               qb.union(function () {

--- a/packages/frontend/src/serverProxy/persons.ts
+++ b/packages/frontend/src/serverProxy/persons.ts
@@ -1,4 +1,5 @@
 import {
+  ChildDictItem,
   Pagination,
   PersonInfo,
   PersonListItem,
@@ -53,10 +54,16 @@ async function getPersonInfo(uuid: string): Promise<PersonInfo> {
   return data;
 }
 
+async function getPersonsByNameUuid(uuid: string): Promise<ChildDictItem[]> {
+  const { data } = await axios.get(`/persons/wordsInTexts/${uuid}`);
+  return data;
+}
+
 export default {
   getPersons,
   getPersonsOccurrencesCounts,
   getPersonsOccurrencesTexts,
   disconnectPersons,
   getPersonInfo,
+  getPersonsByNameUuid,
 };

--- a/packages/frontend/src/views/Search/TextsSearch/components/WordsInTextSearchComboboxItem.vue
+++ b/packages/frontend/src/views/Search/TextsSearch/components/WordsInTextSearchComboboxItem.vue
@@ -1,7 +1,7 @@
 <template>
   <v-list-item-content>
     <div class="d-inline-flex flex-row">
-      <span class="pr-1" v-if="item.type === 'word'"
+      <span class="pr-1" v-if="item.type === 'word' || item.type === 'person'"
         ><b>{{ item.name }}</b>
       </span>
       <span class="pr-1" v-else-if="item.type === 'form'"
@@ -20,6 +20,7 @@
           <span class="pr-1">{{ translationsString }}</span>
         </div>
       </div>
+      <div v-if="item.type === 'person'">(PN)</div>
       <div v-if="item.type === 'form'" class="d-inline-flex flex-row flex-wrap">
         <v-progress-circular
           indeterminate

--- a/packages/types/src/dictionary.ts
+++ b/packages/types/src/dictionary.ts
@@ -225,3 +225,9 @@ export interface TextOccurrencesCountResponseItem {
   uuid: string;
   count: number;
 }
+
+export interface ChildDictItem {
+  name: string;
+  uuid: string;
+  type: 'form' | 'spelling' | 'number' | 'person';
+}

--- a/packages/types/src/words.ts
+++ b/packages/types/src/words.ts
@@ -44,7 +44,7 @@ export interface DictItemComboboxDisplay {
   wordUuid: string;
   translations: DictionaryWordTranslation[] | null;
   formInfo: Omit<DictionaryForm, 'spellings'> | null;
-  type: 'word' | 'form' | 'spelling' | 'number';
+  type: 'word' | 'form' | 'spelling' | 'number' | 'person';
 }
 
 export interface WordsInTextSearchPayload {


### PR DESCRIPTION
This isn't quite done. I'm just putting it up here so that others can work on it. It pretty much works but it does have a few small bugs and some other things that need to be done. I will list them here. 

bug 1: The items list in wordsintextsearch.vue keeps growing and growing and growing. It's messing with the filter (I made it asynchronous bet `getComboboxItems` is messing it up) and sometimes the names of persons won't show up even if it's there, especially if there's a form that is spelled the same way.

bug 2: After searching for a name, sometimes the context portion will display a random portion of the text instead of the person

undone task 1: tests

undone task 2: permissions on how to add in persons to the `/dictItems` route. I assume there will need to be a filter or something

undone task 3: rename some of the types to better show that persons are being included (i.e. 'form/spelling/number')

That's all I can think of, feel free to email or slack or whatever if you have more questions about wordsInTexts search. It's kinda huge and confusing and I apologize for that.